### PR TITLE
UI-Guidelines: Added Typography, weights and sizes

### DIFF
--- a/ui-guidelines/css/guidelines.css
+++ b/ui-guidelines/css/guidelines.css
@@ -1,5 +1,6 @@
 @import url(https://fonts.googleapis.com/css?family=Maven+Pro:400,500,700,900);
 @import url(https://fonts.googleapis.com/css?family=Quantico);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
 
 body {
 	position: relative;
@@ -165,8 +166,23 @@ pre {
 	font-size: 1em;
 	font-weight: bold;
 }
-/*==== HELPERS ====*/
+/*==== UTILITIES/HELPERS ====*/
 .top-half-extra {margin-top: 2em;}
 .top-extra {margin-top: 4em;}
 .top-low {margin-top: 1.5em;}
 .bottom-half-extra {margin-bottom: 1.5em;}
+.u-move-down-xlarge {
+	margin-top: 2em;
+}
+.u-move-left-xlarge {
+	margin-left: 2em;
+}
+.u-move-left {
+	margin-left: 1em;
+}
+.u-move-up-xlarge {
+	margin-top: -2em;
+}
+.u-move-up-xsmall {
+	margin-top: -.5em;
+}

--- a/ui-guidelines/css/resources.css
+++ b/ui-guidelines/css/resources.css
@@ -1,0 +1,53 @@
+/*==== Resources TYPOGRAPHY ====*/
+.typography-row {
+	display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    align-content: space-around;
+    margin-bottom: 2rem;
+}
+.weight-sample {
+	width: 20%;
+	float: left;
+	margin: .5em 2em 1em 0;
+	border: 1px solid #fce3da;
+	border-radius: 8px;
+	text-align: center;
+	font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+}
+.letter-sample {
+	font-size: 6em;
+}
+.weight-text {
+	font-size: .9em;
+}
+.light {
+    font-weight: 300;
+}
+.normal {
+    font-weight: 500;
+}
+.medium {
+    font-weight: 600;
+}
+.bold {
+    font-weight: 700;
+}
+.typography {
+	font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+}
+h1 {
+    font-size: 2.5em;
+}
+h2 {
+    font-size: 2em;
+}
+h3 {
+    font-size: 1.75em;
+}
+h4 {
+    font-size: 1.5em;
+}
+h5 {
+    font-size: 1.25em;
+}

--- a/ui-guidelines/index.html
+++ b/ui-guidelines/index.html
@@ -17,6 +17,7 @@
 
 		<!-- Custom css & js-->
 		<link rel="stylesheet" href="css/guidelines.css">
+		<link rel="stylesheet" href="css/resources.css">
 
 		<!-- Prism - Code snippets -->
 		<link href="css/prism.css" rel="stylesheet">
@@ -96,6 +97,50 @@
 					</div>
 					<hr>
 
+					<div id="resources" class="content-section">
+						<h2 class="font-header">Resources</h2>
+
+						<div id="resources-typography" class="modules">
+							<h3 class="module-header">Typography</h3>
+							<p><strong>Typographic elements do not come with any other styling properties attached</strong> to them in order to emphasize modularity and make them more flexible in where they can be used. If you need to add more styling properties don’t forget to look for any other component before.</p>
+							<h4 class="u-move-down-xlarge">Type weights</h4>
+							<div class="typography-row">
+								<div class="weight-sample">
+									<p class="letter-sample light">A</p>
+									<p class="weight-text u-move-up-xlarge">REGULAR (300)</p>
+								</div>
+								<div class="weight-sample">
+									<p class="letter-sample regular">A</p>
+									<p class="weight-text u-move-up-xlarge">MEDIUM (500)</p>
+								</div>
+								<div class="weight-sample">
+									<p class="letter-sample medium">A</p>
+									<p class="weight-text u-move-up-xlarge">SEMI-BOLD (600)</p>
+								</div>
+								<div class="weight-sample">
+									<p class="letter-sample bold">A</p>
+									<p class="weight-text u-move-up-xlarge">BOLD (700)</p>
+								</div>
+							</div>
+							<h4 class="u-move-down-xlarge">Type sizes</h4>
+							<p>We use standard type sizes and weights to define a layout composition.</p>
+							<div class="typography u-move-left-xlarge">
+								<h1>eZ is an open source content management system</h1>
+								<p class="u-move-up-xsmall"><code>h1</code><span class="u-move-left">2.5em</span></p>
+								<h2>eZ is an open source content management system</h2>
+								<p class="u-move-up-xsmall"><code>h2</code><span class="u-move-left">2em</span></p>
+								<h3>eZ is an open source content management system</h3>
+								<p class="u-move-up-xsmall"><code>h3</code><span class="u-move-left">1.75em</span></p>
+								<h4>eZ is an open source content management system</h4>
+								<p class="u-move-up-xsmall"><code>h4</code><span class="u-move-left">1.5em</span></p>
+								<h5>eZ is an open source content management system</h5>
+								<p class="u-move-up-xsmall"><code>h5</code><span class="u-move-left">1.25em</span></p>
+								<p>eZ is an open source content management system</p>
+								<p class="u-move-up-xsmall"><code>p</code><span class="u-move-left">1em</span></p>
+							</div>
+						</div>
+					</div>
+
 				</div>
 
 				<div class="col-md-2 scrollspy">
@@ -111,6 +156,16 @@
 								<li>
 									<a href="#design-philosophy">
 										<span class="fa fa-angle-right"></span>Philosophy
+									</a>
+								</li>
+							</ul>
+						</li>
+						<li>
+							<a href="#resources">Resources</a>
+							<ul class="nav">
+								<li>
+									<a href="#resources-typography">
+										<span class="fa fa-angle-right"></span>Typography
 									</a>
 								</li>
 							</ul>


### PR DESCRIPTION
Most important aspects:

- Font-family selected: 'Open Sans'.
- Font-weight: `light`, would be discarded. It's mostly used for tooltip text only; we tested, and it's hard to read it for that font-size case.
- Font-weights: `medium` and `semi-bold` are added based on 'Open Sans' specificities and design decisions.
- Proposed `h1` to `h5` only, and `p`. Rest of font-sizes will be component-based, as agreed.
- Font-size base for Platform UI & Studio UI: 15px
- Units. This proposal contains units in `em`s, but it should be discussed at least if we continue with `em` units or if we pick `rem` units instead.
