### PR TITLE
Icons rendered in font-weight bold

### DIFF
--- a/ui-guidelines/css/resources-icons.css
+++ b/ui-guidelines/css/resources-icons.css
@@ -12,7 +12,6 @@
     font-family: 'ez-icons';
     speak: none;
     font-style: normal;
-    font-weight: normal;
     font-variant: normal;
     text-transform: none;
     line-height: 1;


### PR DESCRIPTION
Most important aspects:

- Removed the property `font-weight: normal;` of the standard `.ez-icon` selector class in order to get bolded icons;

- Note: Not all icons will have a `font-weight: bold;` Due to design constraints navbar icons will have a `font-weight: normal;` property. That will be specified accordingly.