### PR TITLE
Updated font weight for outline icons

### DIFF
--- a/ui-guidelines/css/resources-icons.css
+++ b/ui-guidelines/css/resources-icons.css
@@ -12,7 +12,7 @@
     font-family: 'ez-icons';
     speak: none;
     font-style: normal;
-    font-weight: normal;
+    font-weight: bold;
     font-variant: normal;
     text-transform: none;
     line-height: 1;


### PR DESCRIPTION
Most important aspects:
- Increases the `font-weight` of outline icons to `bold` for better rendering purposes.