### PR TITLE
Added icons sizes

### DIFF
--- a/ui-guidelines/css/guidelines.css
+++ b/ui-guidelines/css/guidelines.css
@@ -233,16 +233,12 @@ hr {
 }
 
 .icon-frame {
-    height: 10rem;
-    width: 10rem;
+    height: 11rem;
+    width: 11rem;
     background-color: #f3f3f3;
     border: 1px solid transparent;
     border-radius: 4px;
     text-align: center;
-}
-
-.icon-size {
-    font-size: 32px;
 }
 
 .icon-label {

--- a/ui-guidelines/css/resources-icons.css
+++ b/ui-guidelines/css/resources-icons.css
@@ -21,75 +21,25 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-/*Spinners*/
-.ez-spin {
-    animation: spin 1.75s linear infinite;
+/* Icons sizes */
+.ez-icon-x1 {
+    font-size: 1em;
 }
 
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
+.ez-icon-x2 {
+    font-size: 2em;
 }
 
-.ez-spin-sq-fill {
-    font-size: 2.5rem;
-    position: absolute;
-    margin-top: 1.75rem;
-    margin-left: 1.75rem;
-    background-color: #fff;
-    font-weight: bold;
-    animation: loader 3s infinite ease;
+.ez-icon-x3 {
+    font-size: 2.5em;
 }
 
-@keyframes loader {
-    0% {
-        transform: rotate(0deg);
-    }
-    25% {
-        transform: rotate(180deg);
-    }
-    50% {
-        transform: rotate(180deg);
-    }
-    75% {
-        transform: rotate(360deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
+.ez-icon-x4 {
+    font-size: 3em;
 }
 
-.sq-loader-inner {
-    vertical-align: top;
-    position: absolute;
-    margin-left: -2.35rem;
-    margin-top: 2%;
-    max-height: 87%;
-    width: 87%;
-    background-color: #f05a22;
-    animation: loader-inner 3s infinite ease-in;
-}
-
-@keyframes loader-inner {
-    0% {
-        height: 0%;
-    }
-    25% {
-        height: 0%;
-    }
-    50% {
-        height: 100%;
-    }
-    75% {
-        height: 100%;
-    }
-    100% {
-        height: 0%;
-    }
+.ez-icon-x5 {
+    font-size: 4em;
 }
 
 /*icons*/
@@ -607,4 +557,75 @@
 
 .ez-icon-wiki:before {
     content: "\e980";
+}
+
+/*Spinners*/
+.ez-spin {
+    animation: spin 1.75s linear infinite;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.ez-spin-sq-fill {
+    font-size: 2.5rem;
+    position: absolute;
+    margin-top: 1.75rem;
+    margin-left: 1.75rem;
+    background-color: #fff;
+    font-weight: bold;
+    animation: loader 3s infinite ease;
+}
+
+@keyframes loader {
+    0% {
+        transform: rotate(0deg);
+    }
+    25% {
+        transform: rotate(180deg);
+    }
+    50% {
+        transform: rotate(180deg);
+    }
+    75% {
+        transform: rotate(360deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.sq-loader-inner {
+    vertical-align: top;
+    position: absolute;
+    margin-left: -2.35rem;
+    margin-top: 2%;
+    max-height: 87%;
+    width: 87%;
+    background-color: #f05a22;
+    animation: loader-inner 3s infinite ease-in;
+}
+
+@keyframes loader-inner {
+    0% {
+        height: 0%;
+    }
+    25% {
+        height: 0%;
+    }
+    50% {
+        height: 100%;
+    }
+    75% {
+        height: 100%;
+    }
+    100% {
+        height: 0%;
+    }
 }

--- a/ui-guidelines/index.html
+++ b/ui-guidelines/index.html
@@ -552,7 +552,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-about"></span>
+											<span class="ez-icon-x2 ez-icon-about"></span>
 										</p>
 										<p class="icon-label">.ez-icon-about</p>
 									</div>
@@ -560,7 +560,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-airtime"></span>
+											<span class="ez-icon-x2 ez-icon-airtime"></span>
 										</p>
 										<p class="icon-label">.ez-icon-airtime</p>
 									</div>
@@ -568,7 +568,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-align-center"></span>
+											<span class="ez-icon-x2 ez-icon-align-center"></span>
 										</p>
 										<p class="icon-label">.ez-icon-align-center</p>
 									</div>
@@ -576,7 +576,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-align-justify"></span>
+											<span class="ez-icon-x2 ez-icon-align-justify"></span>
 										</p>
 										<p class="icon-label">.ez-icon-align-justify</p>
 									</div>
@@ -584,7 +584,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-align-left"></span>
+											<span class="ez-icon-x2 ez-icon-align-left"></span>
 										</p>
 										<p class="icon-label">.ez-icon-align-left</p>
 									</div>
@@ -592,7 +592,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-align-right"></span>
+											<span class="ez-icon-x2 ez-icon-align-right"></span>
 										</p>
 										<p class="icon-label">.ez-icon-align-right</p>
 									</div>
@@ -600,7 +600,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-article"></span>
+											<span class="ez-icon-x2 ez-icon-article"></span>
 										</p>
 										<p class="icon-label">.ez-icon-article</p>
 									</div>
@@ -608,7 +608,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-author"></span>
+											<span class="ez-icon-x2 ez-icon-author"></span>
 										</p>
 										<p class="icon-label">.ez-icon-author</p>
 									</div>
@@ -616,7 +616,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-banner"></span>
+											<span class="ez-icon-x2 ez-icon-banner"></span>
 										</p>
 										<p class="icon-label">.ez-icon-banner</p>
 									</div>
@@ -624,7 +624,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-blog-post"></span>
+											<span class="ez-icon-x2 ez-icon-blog-post"></span>
 										</p>
 										<p class="icon-label">.ez-icon-blog-post</p>
 									</div>
@@ -632,7 +632,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-blog"></span>
+											<span class="ez-icon-x2 ez-icon-blog"></span>
 										</p>
 										<p class="icon-label">.ez-icon-blog</p>
 									</div>
@@ -640,7 +640,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-browse"></span>
+											<span class="ez-icon-x2 ez-icon-browse"></span>
 										</p>
 										<p class="icon-label">.ez-icon-browse</p>
 									</div>
@@ -648,7 +648,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-bubbles"></span>
+											<span class="ez-icon-x2 ez-icon-bubbles"></span>
 										</p>
 										<p class="icon-label">.ez-icon-bubbles</p>
 									</div>
@@ -656,7 +656,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-caret-back"></span>
+											<span class="ez-icon-x2 ez-icon-caret-back"></span>
 										</p>
 										<p class="icon-label">.ez-icon-caret-back</p>
 									</div>
@@ -664,7 +664,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-caret-down"></span>
+											<span class="ez-icon-x2 ez-icon-caret-down"></span>
 										</p>
 										<p class="icon-label">.ez-icon-caret-down</p>
 									</div>
@@ -672,7 +672,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-caret-next"></span>
+											<span class="ez-icon-x2 ez-icon-caret-next"></span>
 										</p>
 										<p class="icon-label">.ez-icon-caret-next</p>
 									</div>
@@ -680,7 +680,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-caret-up"></span>
+											<span class="ez-icon-x2 ez-icon-caret-up"></span>
 										</p>
 										<p class="icon-label">.ez-icon-caret-up</p>
 									</div>
@@ -688,7 +688,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-category"></span>
+											<span class="ez-icon-x2 ez-icon-category"></span>
 										</p>
 										<p class="icon-label">.ez-icon-category</p>
 									</div>
@@ -696,7 +696,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-checkmark"></span>
+											<span class="ez-icon-x2 ez-icon-checkmark"></span>
 										</p>
 										<p class="icon-label">.ez-icon-checkmark</p>
 									</div>
@@ -704,7 +704,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-circle-caret-back"></span>
+											<span class="ez-icon-x2 ez-icon-circle-caret-back"></span>
 										</p>
 										<p class="icon-label">.ez-icon-circle-caret-back</p>
 									</div>
@@ -712,7 +712,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-circle-caret-close"></span>
+											<span class="ez-icon-x2 ez-icon-circle-caret-close"></span>
 										</p>
 										<p class="icon-label">.ez-icon-circle-caret-close</p>
 									</div>
@@ -720,7 +720,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-circle-caret-down"></span>
+											<span class="ez-icon-x2 ez-icon-circle-caret-down"></span>
 										</p>
 										<p class="icon-label">.ez-icon-circle-caret-down</p>
 									</div>
@@ -728,7 +728,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-circle-caret-next"></span>
+											<span class="ez-icon-x2 ez-icon-circle-caret-next"></span>
 										</p>
 										<p class="icon-label">.ez-icon-circle-caret-next</p>
 									</div>
@@ -736,7 +736,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-circle-caret-up"></span>
+											<span class="ez-icon-x2 ez-icon-circle-caret-up"></span>
 										</p>
 										<p class="icon-label">.ez-icon-circle-caret-up</p>
 									</div>
@@ -744,7 +744,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-circle-create"></span>
+											<span class="ez-icon-x2 ez-icon-circle-create"></span>
 										</p>
 										<p class="icon-label">.ez-icon-circle-create</p>
 									</div>
@@ -752,7 +752,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-clipboard"></span>
+											<span class="ez-icon-x2 ez-icon-clipboard"></span>
 										</p>
 										<p class="icon-label">.ez-icon-clipboard</p>
 									</div>
@@ -760,7 +760,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-comment"></span>
+											<span class="ez-icon-x2 ez-icon-comment"></span>
 										</p>
 										<p class="icon-label">.ez-icon-comment</p>
 									</div>
@@ -768,7 +768,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-content-list"></span>
+											<span class="ez-icon-x2 ez-icon-content-list"></span>
 										</p>
 										<p class="icon-label">.ez-icon-content-list</p>
 									</div>
@@ -776,7 +776,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-content-types"></span>
+											<span class="ez-icon-x2 ez-icon-content-types"></span>
 										</p>
 										<p class="icon-label">.ez-icon-content-types</p>
 									</div>
@@ -784,7 +784,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-copy"></span>
+											<span class="ez-icon-x2 ez-icon-copy"></span>
 										</p>
 										<p class="icon-label">.ez-icon-copy</p>
 									</div>
@@ -792,7 +792,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-create-content"></span>
+											<span class="ez-icon-x2 ez-icon-create-content"></span>
 										</p>
 										<p class="icon-label">.ez-icon-create-content</p>
 									</div>
@@ -800,7 +800,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-create-landingpage"></span>
+											<span class="ez-icon-x2 ez-icon-create-landingpage"></span>
 										</p>
 										<p class="icon-label">.ez-icon-create-landingpage</p>
 									</div>
@@ -808,7 +808,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-create"></span>
+											<span class="ez-icon-x2 ez-icon-create"></span>
 										</p>
 										<p class="icon-label">.ez-icon-create</p>
 									</div>
@@ -816,7 +816,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-dashboard"></span>
+											<span class="ez-icon-x2 ez-icon-dashboard"></span>
 										</p>
 										<p class="icon-label">.ez-icon-dashboard</p>
 									</div>
@@ -824,7 +824,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-discard"></span>
+											<span class="ez-icon-x2 ez-icon-discard"></span>
 										</p>
 										<p class="icon-label">.ez-icon-discard</p>
 									</div>
@@ -832,7 +832,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-download"></span>
+											<span class="ez-icon-x2 ez-icon-download"></span>
 										</p>
 										<p class="icon-label">.ez-icon-download</p>
 									</div>
@@ -840,7 +840,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-drag"></span>
+											<span class="ez-icon-x2 ez-icon-drag"></span>
 										</p>
 										<p class="icon-label">.ez-icon-drag</p>
 									</div>
@@ -848,7 +848,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-edit"></span>
+											<span class="ez-icon-x2 ez-icon-edit"></span>
 										</p>
 										<p class="icon-label">.ez-icon-edit</p>
 									</div>
@@ -856,7 +856,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-embed"></span>
+											<span class="ez-icon-x2 ez-icon-embed"></span>
 										</p>
 										<p class="icon-label">.ez-icon-embed</p>
 									</div>
@@ -864,7 +864,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-error"></span>
+											<span class="ez-icon-x2 ez-icon-error"></span>
 										</p>
 										<p class="icon-label">.ez-icon-error</p>
 									</div>
@@ -872,7 +872,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-file-text"></span>
+											<span class="ez-icon-x2 ez-icon-file-text"></span>
 										</p>
 										<p class="icon-label">.ez-icon-file-text</p>
 									</div>
@@ -880,7 +880,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-file-video"></span>
+											<span class="ez-icon-x2 ez-icon-file-video"></span>
 										</p>
 										<p class="icon-label">.ez-icon-file-video</p>
 									</div>
@@ -888,7 +888,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-file"></span>
+											<span class="ez-icon-x2 ez-icon-file"></span>
 										</p>
 										<p class="icon-label">.ez-icon-file</p>
 									</div>
@@ -896,7 +896,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-filters"></span>
+											<span class="ez-icon-x2 ez-icon-filters"></span>
 										</p>
 										<p class="icon-label">.ez-icon-filters</p>
 									</div>
@@ -904,7 +904,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-focus"></span>
+											<span class="ez-icon-x2 ez-icon-focus"></span>
 										</p>
 										<p class="icon-label">.ez-icon-focus</p>
 									</div>
@@ -912,7 +912,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-folder"></span>
+											<span class="ez-icon-x2 ez-icon-folder"></span>
 										</p>
 										<p class="icon-label">.ez-icon-folder</p>
 									</div>
@@ -920,7 +920,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-form-data"></span>
+											<span class="ez-icon-x2 ez-icon-form-data"></span>
 										</p>
 										<p class="icon-label">.ez-icon-form-data</p>
 									</div>
@@ -928,7 +928,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-form"></span>
+											<span class="ez-icon-x2 ez-icon-form"></span>
 										</p>
 										<p class="icon-label">.ez-icon-form</p>
 									</div>
@@ -936,7 +936,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-future-publication"></span>
+											<span class="ez-icon-x2 ez-icon-future-publication"></span>
 										</p>
 										<p class="icon-label">.ez-icon-future-publication</p>
 									</div>
@@ -944,7 +944,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-gallery"></span>
+											<span class="ez-icon-x2 ez-icon-gallery"></span>
 										</p>
 										<p class="icon-label">.ez-icon-gallery</p>
 									</div>
@@ -952,7 +952,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-global-content"></span>
+											<span class="ez-icon-x2 ez-icon-global-content"></span>
 										</p>
 										<p class="icon-label">.ez-icon-global-content</p>
 									</div>
@@ -960,7 +960,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-global-page"></span>
+											<span class="ez-icon-x2 ez-icon-global-page"></span>
 										</p>
 										<p class="icon-label">.ez-icon-global-page</p>
 									</div>
@@ -968,7 +968,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-global-performance"></span>
+											<span class="ez-icon-x2 ez-icon-global-performance"></span>
 										</p>
 										<p class="icon-label">.ez-icon-global-performance</p>
 									</div>
@@ -976,7 +976,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-home-page"></span>
+											<span class="ez-icon-x2 ez-icon-home-page"></span>
 										</p>
 										<p class="icon-label">.ez-icon-home-page</p>
 									</div>
@@ -984,7 +984,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-image"></span>
+											<span class="ez-icon-x2 ez-icon-image"></span>
 										</p>
 										<p class="icon-label">.ez-icon-image</p>
 									</div>
@@ -992,7 +992,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-information"></span>
+											<span class="ez-icon-x2 ez-icon-information"></span>
 										</p>
 										<p class="icon-label">.ez-icon-information</p>
 									</div>
@@ -1000,7 +1000,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-keywords"></span>
+											<span class="ez-icon-x2 ez-icon-keywords"></span>
 										</p>
 										<p class="icon-label">.ez-icon-keywords</p>
 									</div>
@@ -1008,7 +1008,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-landingpage"></span>
+											<span class="ez-icon-x2 ez-icon-landingpage"></span>
 										</p>
 										<p class="icon-label">.ez-icon-landingpage</p>
 									</div>
@@ -1016,7 +1016,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-languages"></span>
+											<span class="ez-icon-x2 ez-icon-languages"></span>
 										</p>
 										<p class="icon-label">.ez-icon-languages</p>
 									</div>
@@ -1024,7 +1024,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-link-remove"></span>
+											<span class="ez-icon-x2 ez-icon-link-remove"></span>
 										</p>
 										<p class="icon-label">.ez-icon-link-remove</p>
 									</div>
@@ -1032,7 +1032,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-link"></span>
+											<span class="ez-icon-x2 ez-icon-link"></span>
 										</p>
 										<p class="icon-label">.ez-icon-link</p>
 									</div>
@@ -1040,7 +1040,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-lock"></span>
+											<span class="ez-icon-x2 ez-icon-lock"></span>
 										</p>
 										<p class="icon-label">.ez-icon-lock</p>
 									</div>
@@ -1048,7 +1048,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-maform"></span>
+											<span class="ez-icon-x2 ez-icon-maform"></span>
 										</p>
 										<p class="icon-label">.ez-icon-maform</p>
 									</div>
@@ -1056,7 +1056,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-media"></span>
+											<span class="ez-icon-x2 ez-icon-media"></span>
 										</p>
 										<p class="icon-label">.ez-icon-media</p>
 									</div>
@@ -1064,7 +1064,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-menu"></span>
+											<span class="ez-icon-x2 ez-icon-menu"></span>
 										</p>
 										<p class="icon-label">.ez-icon-menu</p>
 									</div>
@@ -1072,7 +1072,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-merge"></span>
+											<span class="ez-icon-x2 ez-icon-merge"></span>
 										</p>
 										<p class="icon-label">.ez-icon-merge</p>
 									</div>
@@ -1080,7 +1080,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-move"></span>
+											<span class="ez-icon-x2 ez-icon-move"></span>
 										</p>
 										<p class="icon-label">.ez-icon-move</p>
 									</div>
@@ -1088,7 +1088,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-new-tab"></span>
+											<span class="ez-icon-x2 ez-icon-new-tab"></span>
 										</p>
 										<p class="icon-label">.ez-icon-new-tab</p>
 									</div>
@@ -1096,7 +1096,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-news"></span>
+											<span class="ez-icon-x2 ez-icon-news"></span>
 										</p>
 										<p class="icon-label">.ez-icon-news</p>
 									</div>
@@ -1104,7 +1104,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-notice"></span>
+											<span class="ez-icon-x2 ez-icon-notice"></span>
 										</p>
 										<p class="icon-label">.ez-icon-notice</p>
 									</div>
@@ -1112,7 +1112,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-oe-h1"></span>
+											<span class="ez-icon-x2 ez-icon-oe-h1"></span>
 										</p>
 										<p class="icon-label">.ez-icon-oe-h1</p>
 									</div>
@@ -1120,7 +1120,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-oe-list"></span>
+											<span class="ez-icon-x2 ez-icon-oe-list"></span>
 										</p>
 										<p class="icon-label">.ez-icon-oe-list</p>
 									</div>
@@ -1128,7 +1128,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-oe-paragraph"></span>
+											<span class="ez-icon-x2 ez-icon-oe-paragraph"></span>
 										</p>
 										<p class="icon-label">.ez-icon-oe-paragraph</p>
 									</div>
@@ -1136,7 +1136,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-options"></span>
+											<span class="ez-icon-x2 ez-icon-options"></span>
 										</p>
 										<p class="icon-label">.ez-icon-options</p>
 									</div>
@@ -1144,7 +1144,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-panel"></span>
+											<span class="ez-icon-x2 ez-icon-panel"></span>
 										</p>
 										<p class="icon-label">.ez-icon-panel</p>
 									</div>
@@ -1152,7 +1152,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-pdf-file"></span>
+											<span class="ez-icon-x2 ez-icon-pdf-file"></span>
 										</p>
 										<p class="icon-label">.ez-icon-pdf-file</p>
 									</div>
@@ -1160,7 +1160,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-personalize-block"></span>
+											<span class="ez-icon-x2 ez-icon-personalize-block"></span>
 										</p>
 										<p class="icon-label icon-label-line">.ez-icon-personalize-block</p>
 									</div>
@@ -1168,7 +1168,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-personalize-content"></span>
+											<span class="ez-icon-x2 ez-icon-personalize-content"></span>
 										</p>
 										<p class="icon-label icon-label-line">.ez-icon-personalize-content</p>
 									</div>
@@ -1176,7 +1176,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-pin"></span>
+											<span class="ez-icon-x2 ez-icon-pin"></span>
 										</p>
 										<p class="icon-label">.ez-icon-pin</p>
 									</div>
@@ -1184,7 +1184,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-pin-unpin"></span>
+											<span class="ez-icon-x2 ez-icon-pin-unpin"></span>
 										</p>
 										<p class="icon-label">.ez-icon-pin-unpin</p>
 									</div>
@@ -1192,7 +1192,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-place-list"></span>
+											<span class="ez-icon-x2 ez-icon-place-list"></span>
 										</p>
 										<p class="icon-label">.ez-icon-place-list</p>
 									</div>
@@ -1200,7 +1200,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-place"></span>
+											<span class="ez-icon-x2 ez-icon-place"></span>
 										</p>
 										<p class="icon-label">.ez-icon-place</p>
 									</div>
@@ -1208,7 +1208,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-portfolio"></span>
+											<span class="ez-icon-x2 ez-icon-portfolio"></span>
 										</p>
 										<p class="icon-label">.ez-icon-portfolio</p>
 									</div>
@@ -1216,7 +1216,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-product-list"></span>
+											<span class="ez-icon-x2 ez-icon-product-list"></span>
 										</p>
 										<p class="icon-label">.ez-icon-product-list</p>
 									</div>
@@ -1224,7 +1224,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-product"></span>
+											<span class="ez-icon-x2 ez-icon-product"></span>
 										</p>
 										<p class="icon-label">.ez-icon-product</p>
 									</div>
@@ -1232,7 +1232,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-publish-later-cancel"></span>
+											<span class="ez-icon-x2 ez-icon-publish-later-cancel"></span>
 										</p>
 										<p class="icon-label">.ez-icon-publish-later-cancel</p>
 									</div>
@@ -1240,7 +1240,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-publish-later"></span>
+											<span class="ez-icon-x2 ez-icon-publish-later"></span>
 										</p>
 										<p class="icon-label">.ez-icon-publish-later</p>
 									</div>
@@ -1248,7 +1248,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-publish"></span>
+											<span class="ez-icon-x2 ez-icon-publish"></span>
 										</p>
 										<p class="icon-label">.ez-icon-publish</p>
 									</div>
@@ -1256,7 +1256,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-recommended"></span>
+											<span class="ez-icon-x2 ez-icon-recommended"></span>
 										</p>
 										<p class="icon-label">.ez-icon-recommended</p>
 									</div>
@@ -1264,7 +1264,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-refresh"></span>
+											<span class="ez-icon-x2 ez-icon-refresh"></span>
 										</p>
 										<p class="icon-label">.ez-icon-refresh</p>
 									</div>
@@ -1272,7 +1272,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-relations"></span>
+											<span class="ez-icon-x2 ez-icon-relations"></span>
 										</p>
 										<p class="icon-label">.ez-icon-relations</p>
 									</div>
@@ -1280,7 +1280,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-review"></span>
+											<span class="ez-icon-x2 ez-icon-review"></span>
 										</p>
 										<p class="icon-label">.ez-icon-review</p>
 									</div>
@@ -1288,7 +1288,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-roles"></span>
+											<span class="ez-icon-x2 ez-icon-roles"></span>
 										</p>
 										<p class="icon-label">.ez-icon-roles</p>
 									</div>
@@ -1296,7 +1296,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-rss"></span>
+											<span class="ez-icon-x2 ez-icon-rss"></span>
 										</p>
 										<p class="icon-label">.ez-icon-rss</p>
 									</div>
@@ -1304,7 +1304,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-save"></span>
+											<span class="ez-icon-x2 ez-icon-save"></span>
 										</p>
 										<p class="icon-label">.ez-icon-save</p>
 									</div>
@@ -1312,7 +1312,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-schedule"></span>
+											<span class="ez-icon-x2 ez-icon-schedule"></span>
 										</p>
 										<p class="icon-label">.ez-icon-schedule</p>
 									</div>
@@ -1320,7 +1320,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-search"></span>
+											<span class="ez-icon-x2 ez-icon-search"></span>
 										</p>
 										<p class="icon-label">.ez-icon-search</p>
 									</div>
@@ -1328,7 +1328,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-sections"></span>
+											<span class="ez-icon-x2 ez-icon-sections"></span>
 										</p>
 										<p class="icon-label">.ez-icon-sections</p>
 									</div>
@@ -1336,7 +1336,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-settings-block"></span>
+											<span class="ez-icon-x2 ez-icon-settings-block"></span>
 										</p>
 										<p class="icon-label">.ez-icon-settings-block</p>
 									</div>
@@ -1344,7 +1344,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-shuffle"></span>
+											<span class="ez-icon-x2 ez-icon-shuffle"></span>
 										</p>
 										<p class="icon-label">.ez-icon-shuffle</p>
 									</div>
@@ -1352,7 +1352,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-stats"></span>
+											<span class="ez-icon-x2 ez-icon-stats"></span>
 										</p>
 										<p class="icon-label">.ez-icon-stats</p>
 									</div>
@@ -1360,7 +1360,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-subscriber"></span>
+											<span class="ez-icon-x2 ez-icon-subscriber"></span>
 										</p>
 										<p class="icon-label">.ez-icon-subscriber</p>
 									</div>
@@ -1368,7 +1368,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-swap"></span>
+											<span class="ez-icon-x2 ez-icon-swap"></span>
 										</p>
 										<p class="icon-label">.ez-icon-swap</p>
 									</div>
@@ -1376,7 +1376,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-system-information"></span>
+											<span class="ez-icon-x2 ez-icon-system-information"></span>
 										</p>
 										<p class="icon-label">.ez-icon-system-information</p>
 									</div>
@@ -1384,7 +1384,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-tag"></span>
+											<span class="ez-icon-x2 ez-icon-tag"></span>
 										</p>
 										<p class="icon-label">.ez-icon-tag</p>
 									</div>
@@ -1392,7 +1392,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-tags"></span>
+											<span class="ez-icon-x2 ez-icon-tags"></span>
 										</p>
 										<p class="icon-label">.ez-icon-tags</p>
 									</div>
@@ -1400,7 +1400,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-translation"></span>
+											<span class="ez-icon-x2 ez-icon-translation"></span>
 										</p>
 										<p class="icon-label">.ez-icon-translation</p>
 									</div>
@@ -1408,7 +1408,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-trash"></span>
+											<span class="ez-icon-x2 ez-icon-trash"></span>
 										</p>
 										<p class="icon-label">.ez-icon-trash</p>
 									</div>
@@ -1416,7 +1416,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-trash-empty"></span>
+											<span class="ez-icon-x2 ez-icon-trash-empty"></span>
 										</p>
 										<p class="icon-label">.ez-icon-trash-empty</p>
 									</div>
@@ -1424,7 +1424,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-trash-send"></span>
+											<span class="ez-icon-x2 ez-icon-trash-send"></span>
 										</p>
 										<p class="icon-label">.ez-icon-trash-send</p>
 									</div>
@@ -1432,7 +1432,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-upload"></span>
+											<span class="ez-icon-x2 ez-icon-upload"></span>
 										</p>
 										<p class="icon-label">.ez-icon-upload</p>
 									</div>
@@ -1440,7 +1440,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-user"></span>
+											<span class="ez-icon-x2 ez-icon-user"></span>
 										</p>
 										<p class="icon-label">.ez-icon-user</p>
 									</div>
@@ -1448,7 +1448,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-users"></span>
+											<span class="ez-icon-x2 ez-icon-users"></span>
 										</p>
 										<p class="icon-label">.ez-icon-users</p>
 									</div>
@@ -1456,7 +1456,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-versions"></span>
+											<span class="ez-icon-x2 ez-icon-versions"></span>
 										</p>
 										<p class="icon-label">.ez-icon-versions</p>
 									</div>
@@ -1464,7 +1464,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-video"></span>
+											<span class="ez-icon-x2 ez-icon-video"></span>
 										</p>
 										<p class="icon-label">.ez-icon-video</p>
 									</div>
@@ -1472,7 +1472,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-view-custom"></span>
+											<span class="ez-icon-x2 ez-icon-view-custom"></span>
 										</p>
 										<p class="icon-label">.ez-icon-view-custom</p>
 									</div>
@@ -1480,7 +1480,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-view-grid"></span>
+											<span class="ez-icon-x2 ez-icon-view-grid"></span>
 										</p>
 										<p class="icon-label">.ez-icon-view-grid</p>
 									</div>
@@ -1488,7 +1488,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-view-list"></span>
+											<span class="ez-icon-x2 ez-icon-view-list"></span>
 										</p>
 										<p class="icon-label">.ez-icon-view-list</p>
 									</div>
@@ -1496,7 +1496,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-view-desktop"></span>
+											<span class="ez-icon-x2 ez-icon-view-desktop"></span>
 										</p>
 										<p class="icon-label">.ez-icon-view-desktop</p>
 									</div>
@@ -1504,7 +1504,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-view-tablet"></span>
+											<span class="ez-icon-x2 ez-icon-view-tablet"></span>
 										</p>
 										<p class="icon-label">.ez-icon-view-tablet</p>
 									</div>
@@ -1512,7 +1512,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-view-mobile"></span>
+											<span class="ez-icon-x2 ez-icon-view-mobile"></span>
 										</p>
 										<p class="icon-label">.ez-icon-view-mobile</p>
 									</div>
@@ -1520,7 +1520,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-view"></span>
+											<span class="ez-icon-x2 ez-icon-view"></span>
 										</p>
 										<p class="icon-label">.ez-icon-view</p>
 									</div>
@@ -1528,7 +1528,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-view-hide"></span>
+											<span class="ez-icon-x2 ez-icon-view-hide"></span>
 										</p>
 										<p class="icon-label">.ez-icon-view-hide</p>
 									</div>
@@ -1536,7 +1536,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-wand"></span>
+											<span class="ez-icon-x2 ez-icon-wand"></span>
 										</p>
 										<p class="icon-label">.ez-icon-wand</p>
 									</div>
@@ -1544,7 +1544,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-warning"></span>
+											<span class="ez-icon-x2 ez-icon-warning"></span>
 										</p>
 										<p class="icon-label">.ez-icon-warning</p>
 									</div>
@@ -1552,7 +1552,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-wiki-file"></span>
+											<span class="ez-icon-x2 ez-icon-wiki-file"></span>
 										</p>
 										<p class="icon-label">.ez-icon-wiki-file</p>
 									</div>
@@ -1560,7 +1560,7 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-xlow">
-											<span class="icon-size ez-icon-wiki"></span>
+											<span class="ez-icon-x2 ez-icon-wiki"></span>
 										</p>
 										<p class="icon-label">.ez-icon-wiki</p>
 									</div>
@@ -1568,7 +1568,7 @@
 							</div>
 							<h4>Icon sizes</h4>
 							<hr>
-							<p>To increase icon sizes use the <code>.ez-icon-x1</code>, <code>.ez-icon-x2</code>, <code>.ez-icon-x3</code>, <code>.ez-icon-x4</code>, or <code>.ez-icon-x5</code> classes.</p>
+							<p>To increase icon sizes use the <code>.ez-icon-x1</code>, <code>.ez-icon-x2</code>, <code>.ez-icon-x2</code>, <code>.ez-icon-x4</code>, or <code>.ez-icon-x5</code> classes.</p>
 							<div class="flex-wrapper">
 								<div class="icon-box">
 									<div class="icon-frame">
@@ -1589,9 +1589,9 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-min">
-											<span class="ez-icon-image ez-icon-x3"></span>
+											<span class="ez-icon-image ez-icon-x2"></span>
 										</p>
-										<p class="icon-label">.ez-icon-x3</p>
+										<p class="icon-label">.ez-icon-x2</p>
 									</div>
 								</div>
 								<div class="icon-box">
@@ -1618,7 +1618,7 @@
 							    <div class="icon-box">
 							        <div class="icon-frame">
 							            <p class="top-min">
-							                <span class="icon-size ez-spin ez-icon-settings-block"></span>
+							                <span class="ez-icon-x2 ez-spin ez-icon-settings-block"></span>
 							            </p>
 							            <p class="icon-label">.ez-spin</br><span>.ez-icon-settings-block</span></p>
 							        </div>
@@ -1626,7 +1626,7 @@
 							    <div class="icon-box">
 							        <div class="icon-frame">
 							            <p class="top-min">
-							                <span class="icon-size ez-spin ez-icon-review"></span>
+							                <span class="ez-icon-x2 ez-spin ez-icon-review"></span>
 							            </p>
 							            <p class="icon-label">.ez-spin</br><span>.ez-icon-review</span></p>
 							        </div>
@@ -1634,7 +1634,7 @@
 							    <div class="icon-box">
 							        <div class="icon-frame">
 							            <p class="top-min">
-							                <span class="icon-size ez-spin ez-icon-refresh"></span>
+							                <span class="ez-icon-x2 ez-spin ez-icon-refresh"></span>
 							            </p>
 							            <p class="icon-label">.ez-spin</br><span>.ez-icon-refresh</span></p>
 							        </div>
@@ -1645,7 +1645,7 @@
 								<div class="icon-box">
 							        <div class="icon-frame">
 							            <p class="top-min">
-							                <span class="icon-size ez-spin ez-icon-panel"></span>
+							                <span class="ez-icon-x2 ez-spin ez-icon-panel"></span>
 							            </p>
 							            <p class="icon-label">.ez-spin</br><span>.ez-icon-panel</span></p>
 							        </div>
@@ -1654,7 +1654,7 @@
 								    <div class="icon-frame">
 								        <p class="top-min">
 								            <span class="ez-spin-sq-fill ez-icon-square"><span class="sq-loader-inner"></span></span>
-								            <span class="icon-size ez-icon-square"></span>
+								            <span class="ez-icon-x2 ez-icon-square"></span>
 								        </p>
 								        <p class="icon-label icon-label-line top-min">.ez-spin-sq-fill</br>.sq-loader-inner</br><span>.ez-icon-square</span></p>
 								    </div>

--- a/ui-guidelines/index.html
+++ b/ui-guidelines/index.html
@@ -1566,6 +1566,51 @@
 									</div>
 								</div>
 							</div>
+							<h4>Icon sizes</h4>
+							<hr>
+							<p>To increase icon sizes use the <code>.ez-icon-x1</code>, <code>.ez-icon-x2</code>, <code>.ez-icon-x3</code>, <code>.ez-icon-x4</code>, or <code>.ez-icon-x5</code> classes.</p>
+							<div class="flex-wrapper">
+								<div class="icon-box">
+									<div class="icon-frame">
+										<p class="top-min">
+											<span class="ez-icon-image ez-icon-x1"></span>
+										</p>
+										<p class="icon-label">.ez-icon-x1</p>
+									</div>
+								</div>
+								<div class="icon-box">
+									<div class="icon-frame">
+										<p class="top-min">
+											<span class="ez-icon-image ez-icon-x2"></span>
+										</p>
+										<p class="icon-label">.ez-icon-x2</p>
+									</div>
+								</div>
+								<div class="icon-box">
+									<div class="icon-frame">
+										<p class="top-min">
+											<span class="ez-icon-image ez-icon-x3"></span>
+										</p>
+										<p class="icon-label">.ez-icon-x3</p>
+									</div>
+								</div>
+								<div class="icon-box">
+									<div class="icon-frame">
+										<p class="top-min">
+											<span class="ez-icon-image ez-icon-x4"></span>
+										</p>
+										<p class="icon-label">.ez-icon-x4</p>
+									</div>
+								</div>
+								<div class="icon-box">
+									<div class="icon-frame">
+										<p class="top-min">
+											<span class="ez-icon-image ez-icon-x5"></span>
+										</p>
+										<p class="icon-label">.ez-icon-x5</p>
+									</div>
+								</div>
+							</div>	
 							<h4>Spinners</h4>
 							<hr>
 							<p>Use the <code>.ez-spin</code> class to get any icon to rotate.</p>

--- a/ui-guidelines/index.html
+++ b/ui-guidelines/index.html
@@ -1568,7 +1568,7 @@
 							</div>
 							<h4>Icon sizes</h4>
 							<hr>
-							<p>To increase icon sizes use the <code>.ez-icon-x1</code>, <code>.ez-icon-x2</code>, <code>.ez-icon-x2</code>, <code>.ez-icon-x4</code>, or <code>.ez-icon-x5</code> classes.</p>
+							<p>To increase icon sizes use the <code>.ez-icon-x1</code>, <code>.ez-icon-x2</code>, <code>.ez-icon-x3</code>, <code>.ez-icon-x4</code>, or <code>.ez-icon-x5</code> classes.</p>
 							<div class="flex-wrapper">
 								<div class="icon-box">
 									<div class="icon-frame">
@@ -1589,9 +1589,9 @@
 								<div class="icon-box">
 									<div class="icon-frame">
 										<p class="top-min">
-											<span class="ez-icon-image ez-icon-x2"></span>
+											<span class="ez-icon-image ez-icon-x3"></span>
 										</p>
-										<p class="icon-label">.ez-icon-x2</p>
+										<p class="icon-label">.ez-icon-x3</p>
 									</div>
 								</div>
 								<div class="icon-box">


### PR DESCRIPTION
Most important aspects:

- Added sizes to icons based on standard sizes we need;
- Size classes are: `ez-icon-x1` (=1em), `ez-icon-x2` (=2em), `ez-icon-x3` (=2.5em), `ez-icon-x4` (=3em) and `ez-icon-x5` (=4em).

<img width="1280" alt="screen shot 2017-03-22 at 11 35 09 am" src="https://cloud.githubusercontent.com/assets/9256718/24206105/b2cbaee2-0ef3-11e7-962e-6cf4bc98e9d4.png">
