### PR TITLE
Spinners update based on icon sizes

### DIFF
--- a/ui-guidelines/css/guidelines.css
+++ b/ui-guidelines/css/guidelines.css
@@ -241,6 +241,11 @@ hr {
     text-align: center;
 }
 
+.icon-frame-spinner {
+    height: 13rem;
+    width: 13rem;
+}
+
 .icon-label {
     margin-top: -1rem;
     padding: 0 .5rem;

--- a/ui-guidelines/css/resources-icons.css
+++ b/ui-guidelines/css/resources-icons.css
@@ -443,7 +443,7 @@
     content: "\e963";
 }
 
-.ez-icon-spinner:before {
+.ez-icon-loading:before {
     content: "\e964";
 }
 
@@ -573,59 +573,42 @@
     }
 }
 
-.ez-spin-sq-fill {
-    font-size: 2.5rem;
-    position: absolute;
-    margin-top: 1.75rem;
-    margin-left: 1.75rem;
+.ez-icon-square {
     background-color: #fff;
-    font-weight: bold;
-    animation: loader 3s infinite ease;
 }
 
-@keyframes loader {
+.ez-square-clock {
+    position: absolute;
+    background-color: #f15922;
+    z-index: 10;
+    margin-top: .65em;
+    margin-left: .65em;
+    animation: clock 2s linear infinite;
+}
+
+@keyframes clock {
     0% {
         transform: rotate(0deg);
+        background-color: #fff;
     }
+
     25% {
         transform: rotate(180deg);
+        background: #fff;
     }
+
     50% {
         transform: rotate(180deg);
+        background: #f15922;
     }
+
     75% {
         transform: rotate(360deg);
+        background: #f15922;
     }
+
     100% {
         transform: rotate(360deg);
-    }
-}
-
-.sq-loader-inner {
-    vertical-align: top;
-    position: absolute;
-    margin-left: -2.35rem;
-    margin-top: 2%;
-    max-height: 87%;
-    width: 87%;
-    background-color: #f05a22;
-    animation: loader-inner 3s infinite ease-in;
-}
-
-@keyframes loader-inner {
-    0% {
-        height: 0%;
-    }
-    25% {
-        height: 0%;
-    }
-    50% {
-        height: 100%;
-    }
-    75% {
-        height: 100%;
-    }
-    100% {
-        height: 0%;
+        background: #fff;
     }
 }

--- a/ui-guidelines/index.html
+++ b/ui-guidelines/index.html
@@ -1640,14 +1640,22 @@
 							        </div>
 							    </div>
 							</div>
-							<p>We also use <code>.ez-icon-panel</code> for when content is loading within a specific view &#38; <code>.ez-spin-sq-fill</code> to animate our logo when transitioning from one view to another one.</p>
+							<p>We also use <code>.ez-icon-spinner</code> for when content is loading within a specific view &#38; <code>.ez-spin-sq-fill</code> to animate our logo when transitioning from one view to another one.</p>
 							<div class="flex-wrapper">
 								<div class="icon-box">
 							        <div class="icon-frame">
 							            <p class="top-min">
-							                <span class="ez-icon-x2 ez-spin ez-icon-panel"></span>
+							                <span class="ez-icon-x1 ez-spin ez-icon-spinner"></span>
 							            </p>
-							            <p class="icon-label">.ez-spin</br><span>.ez-icon-panel</span></p>
+							            <p class="icon-label">.ez-spin</br>.ez-icon-x1</br><span>.ez-icon-spinner</span></p>
+							        </div>
+							    </div>
+							    <div class="icon-box">
+							        <div class="icon-frame">
+							            <p class="top-min">
+							                <span class="ez-icon-x2 ez-spin ez-icon-spinner"></span>
+							            </p>
+							            <p class="icon-label">.ez-spin</br>.ez-icon-x2</br><span>.ez-icon-spinner</span></p>
 							        </div>
 							    </div>
 							    <div class="icon-box">

--- a/ui-guidelines/index.html
+++ b/ui-guidelines/index.html
@@ -1611,7 +1611,7 @@
 									</div>
 								</div>
 							</div>	
-							<h4>Spinners</h4>
+							<h4>Animated icons</h4>
 							<hr>
 							<p>Use the <code>.ez-spin</code> class to get any icon to rotate.</p>
 							<div class="flex-wrapper">
@@ -1640,31 +1640,36 @@
 							        </div>
 							    </div>
 							</div>
-							<p>We also use <code>.ez-icon-spinner</code> for when content is loading within a specific view &#38; <code>.ez-spin-sq-fill</code> to animate our logo when transitioning from one view to another one.</p>
+							<h4>Loading icons</h4>
+							<hr>
+							<p>We use <code>.ez-spin</code> &#38; <code>.ez-icon-loading</code> for when content is loading within a specific view.</p>
 							<div class="flex-wrapper">
 								<div class="icon-box">
 							        <div class="icon-frame">
 							            <p class="top-min">
-							                <span class="ez-icon-x1 ez-spin ez-icon-spinner"></span>
+							                <span class="ez-icon-x1 ez-spin ez-icon-loading"></span>
 							            </p>
-							            <p class="icon-label">.ez-spin</br>.ez-icon-x1</br><span>.ez-icon-spinner</span></p>
+							            <p class="icon-label">.ez-spin</br>.ez-icon-x1</br><span>.ez-icon-loading</span></p>
 							        </div>
 							    </div>
 							    <div class="icon-box">
 							        <div class="icon-frame">
 							            <p class="top-min">
-							                <span class="ez-icon-x2 ez-spin ez-icon-spinner"></span>
+							                <span class="ez-icon-x2 ez-spin ez-icon-loading"></span>
 							            </p>
-							            <p class="icon-label">.ez-spin</br>.ez-icon-x2</br><span>.ez-icon-spinner</span></p>
+							            <p class="icon-label">.ez-spin</br>.ez-icon-x2</br><span>.ez-icon-loading</span></p>
 							        </div>
 							    </div>
+							</div>
+							<p>We also use <code>.ez-square-clock</code> to animate our logo when transitioning from one view to another one.</p>
+							<div class="flex-wrapper">
 							    <div class="icon-box">
-								    <div class="icon-frame">
+								    <div class="icon-frame icon-frame-spinner">
 								        <p class="top-min">
-								            <span class="ez-spin-sq-fill ez-icon-square"><span class="sq-loader-inner"></span></span>
-								            <span class="ez-icon-x2 ez-icon-square"></span>
+								            <span class="ez-square-clock ez-icon-square ez-icon-x3"></span>
+								            <span class="ez-icon-x4 ez-icon-square"></span>
 								        </p>
-								        <p class="icon-label icon-label-line top-min">.ez-spin-sq-fill</br>.sq-loader-inner</br><span>.ez-icon-square</span></p>
+								        <p class="icon-label top-half-extra">.ez-square-clock</br><span>.ez-icon-square</span></p>
 								    </div>
 								</div>
 							</div>


### PR DESCRIPTION
Most important aspects:

- After several reviews, a small spinner is defined, `.ez-icon-spinner`, for when content is loading within a specific view;
- An animated eZ logo is the spinner defined, when transitioning from one view to another.

<img width="1280" alt="screen shot 2017-03-22 at 12 56 45 pm" src="https://cloud.githubusercontent.com/assets/9256718/24210310/1552a736-0eff-11e7-84af-03c0daf7d4d8.png">
