### PR TITLE
Added modals

### DIFF
--- a/ui-guidelines/css/components-modals.css
+++ b/ui-guidelines/css/components-modals.css
@@ -1,0 +1,166 @@
+
+.ez-modal {
+    position: fixed;
+    display: block;    
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    z-index: 9999;
+}
+
+.ez-modal .modal-container {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+}
+
+.ez-modal .modal-content {
+    position: relative;
+    display: inline-block;
+    top: 75px;
+    margin: 0 auto;
+    width: auto;
+    max-width: 80%;
+    max-height: 70vh;
+    border-radius: 8px;
+    background-color: #e5e5e5;
+    box-shadow: 0 0 0 rgba(0,0,0,0);
+    transition: transform .4s ease-in;
+    -webkit-transform: scale3d(0,0,1);
+        -ms-transform: scale3d(0,0,1);
+            transform: scale3d(0,0,1);
+}
+
+.ez-modal:before {
+    content: "";
+    position: fixed;
+    display: none;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    background-color: rgba(0,0,0,.7);
+}
+
+.ez-modal:target:before {
+    display: block;
+}
+
+.ez-modal:target {
+    display: block;
+    pointer-events: auto;
+}
+
+.ez-modal:target .modal-content {
+    top: 75px;
+    box-shadow: 0 3px 20px rgba(0,0,0,0.6);
+    -webkit-transform: scale3d(1,1,1);
+        -ms-transform: scale3d(1,1,1);
+            transform: scale3d(1,1,1);
+}
+
+.ez-modal .modal-content .header {
+    height: 60px;
+    border-radius: 8px 8px 0 0;
+    background: #bfbfbf;
+}
+
+.ez-modal .modal-content .header h2 {
+    margin: 0;
+    padding: 0 1em 0;
+    color: #333;
+    font-size: 1.6em;
+    line-height: 60px;
+}
+
+.ez-modal .modal-content .header a {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 15px 15px 0 0;
+    border-radius: 50px;
+    padding: .5em .5em;
+    color: #848484;
+    font-weight: bold;
+    background-color: transparent;
+    text-align: right;
+    line-height: 5px;
+    cursor: pointer;
+}
+
+.ez-modal .modal-content .header a:hover,
+.ez-modal .modal-content .header a:focus {
+    color: #fff;
+    background-color: rgba(216,216,216,.5);
+    cursor: pointer;
+}
+
+.ez-modal .modal-content .body { 
+    max-height: 80%;
+    border-radius: 8px 8px 0 0;
+    padding: 1em 3.33em;
+    background: #e5e5e5;
+    overflow-y: scroll;
+}
+
+.ez-modal .modal-content .body::-webkit-scrollbar {
+    width: 7px;
+    -webkit-appearance: none;
+}
+
+.ez-modal .modal-content .body::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0,0,0,.5);
+    -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+}
+
+.ez-modal .modal-content .footer {
+    border-radius: 0 0 8px 8px;
+    padding: 1em 3.33em;
+    background-color: #dcdcdc;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.ez-modal .modal-content .footer button:last-child {
+    margin-left: 1em;
+}
+
+.ez-modal .modal-content .footer a {
+    text-decoration: none;
+}
+
+.ez-modal.ez-modal-header .modal-content {
+    max-height: 62vh;
+}
+
+.ez-modal.ez-modal-header .modal-content .body {
+    border-radius: 8px 8px 0 0;
+    padding: 2em 3.33em 1em 3.33em;
+}
+
+.ez-modal.ez-modal-header .modal-content .footer {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    justify-content: center;
+    padding: 1em 0;
+    background-color: #dcdcdc;
+}
+
+.ez-modal.ez-modal-header-nofooter .modal-content {
+    max-height: 62vh;
+    min-width: 55%;
+}
+
+.ez-modal.ez-modal-header-nofooter .modal-content .body {
+    border-radius: 8px;
+    padding: 2em 3.33em;
+}

--- a/ui-guidelines/css/guidelines.css
+++ b/ui-guidelines/css/guidelines.css
@@ -322,6 +322,21 @@ pre[class*="language-"] {
     margin-bottom: 1.5em;
 }
 
+/* Components - Modals */
+.modal-button {
+    margin-top: 1.5em;
+    padding: 1em 2em;
+    border-radius: 4px;
+    background-color: #f15a10;
+    color: #fff;
+}
+
+.modal-button:hover {
+    color: #fff;
+    background-color: #c3480b;
+    text-decoration: none;
+}
+
 /*==== UTILITIES/HELPERS ====*/
 .top-half-extra {
     margin-top: 2em;

--- a/ui-guidelines/index.html
+++ b/ui-guidelines/index.html
@@ -27,6 +27,7 @@
 		<link rel="stylesheet" href="css/guidelines.css">
 		<link rel="stylesheet" href="css/components-buttons.css">
 		<link rel="stylesheet" href="css/components-form.css">
+		<link rel="stylesheet" href="css/components-modals.css">
 		<link rel="stylesheet" href="css/components-tables.css">
 		<link rel="stylesheet" href="css/resources-typography.css">
 		<link rel="stylesheet" href="css/resources-colors.css">
@@ -781,6 +782,192 @@
 					                    </table>
 					                </div>
 					            </div>
+							</div>
+						</div>
+						<div id="components-modals" class="modules">
+							<h3 class="module-header">Modals</h3>
+							<h4 class="u-move-down-xlarge">Modal without header</h4>
+							<hr>
+							<div class="flex-wrapper">
+<pre>
+<code class="line-numbers language-markup"><script type="prism-html-markup"><div id="modal1" class="ez-modal" role="dialog" aria-labelledby="ez-modal">
+    <div class="modal-container">
+        <div class="modal-content">
+            <div class="body" aria-labelledby="ez-modal_body">
+                Your content here
+            </div>
+            <div class="footer" aria-labelledby="ez-modal_buttons">
+                Include interaction buttons here
+            </div>
+        </div>
+    </div>
+</div></script></code>
+</pre>					
+								<div id="modal1" class="ez-modal" role="dialog" aria-labelledby="ez-modal">
+					                <div class="modal-container">
+					                    <div class="modal-content">
+					                        <div class="body" aria-labelledby="ez-modal_body">
+					                            <p>Are you sure you want to send this content to trash?</p>
+					                        </div>
+					                        <div class="footer" aria-labelledby="ez-modal_buttons">
+					                            <a href="#" data-dismiss="modal"><button type="button" class="ez-button ez-button-neutral">Cancel</button></a>
+					                            <a href="#"><button type="button" class="ez-button ez-button-negative">Send to trash</button></a>
+					                        </div>
+					                    </div>
+					                </div>
+					            </div>	
+					            <a href="#modal1" data-target="#modal1" class="modal-button">Launch modal without header</a>
+							</div>
+							<h4 class="u-move-down-xlarge">Modal with header, but without footer</h4>
+							<hr>
+							<div class="flex-wrapper">
+<pre>
+<code class="line-numbers language-markup"><script type="prism-html-markup"><div id="modal2" class="ez-modal ez-modal-header-nofooter" role="dialog" aria-labelledby="ez-modal">
+    <div class="modal-container">
+        <div class="modal-content">
+        	<div class="header" aria-labelledby="ez-modal_header">
+                <h2>Header here</h2>
+                <a href="#" data-dismiss="modal"><span class="ez-icon-discard"></span></a>
+            </div>
+            <div class="body" aria-labelledby="ez-modal_body">
+                Your content here
+            </div>
+        </div>
+    </div>
+</div></script></code>
+</pre>	
+								<div id="modal2" class="ez-modal ez-modal-header-nofooter" role="dialog" aria-labelledby="ez-modal">
+					                <div class="modal-container">
+					                    <div class="modal-content">
+					                        <div class="header" aria-labelledby="ez-modal_header">
+					                            <h2>Header here</h2>
+					                            <a href="#" data-dismiss="modal"><span class="ez-icon-discard"></span></a>
+					                        </div>
+					                        <div class="body" aria-labelledby="ez-modal_body">
+					                            <div class="ez-table ez-table-checkboxes">
+					                                <div class="table-title">
+					                                    <p>Drafts</p>
+					                                    <div class="container-buttons">
+					                                        <button type="button" class="ez-button ez-button-secondary"><span class="ez-icon-create"></span>Add draft</button> 
+					                                    </div>
+					                                </div>
+					                                <div class="table-container">
+					                                    <table>
+					                                        <tr>
+					                                            <th>Language</th>
+					                                            <th>Owner</th>
+					                                            <th>Last modified</th>
+					                                            <th></th>
+					                                        </tr>
+					                                        <tr>
+					                                            <td>eng-GB</td>
+					                                            <td>Admin user</td>
+					                                            <td>17 Sep 2015, 12:53 PM</td>
+					                                            <td></td>
+					                                        </tr>
+					                                        <tr>
+					                                            <td>eng-GB</td>
+					                                            <td>Alexandra Lewis</td>
+					                                            <td>17 Sep 2015, 2:53 PM</td>
+					                                            <td>
+					                                                <a href="#" class="table-iconbutton">
+					                                                    <div class="table-iconbutton-edit">
+					                                                        <span class="ez-icon-edit"></span>
+					                                                    </div>
+					                                                </a>
+					                                            </td>
+					                                        </tr>
+					                                        <tr>
+					                                            <td>eng-GB</td>
+					                                            <td>Alexandra Lewis</td>
+					                                            <td>20 Sep 2015, 4:53 PM</td>
+					                                            <td>
+					                                                <a href="#" class="table-iconbutton">
+					                                                    <div class="table-iconbutton-edit">
+					                                                        <span class="ez-icon-edit"></span>
+					                                                    </div>
+					                                                </a>
+					                                            </td>
+					                                        </tr>
+					                                    </table>
+					                                </div>
+					                            </div>
+					                        </div>
+					                    </div>
+					                </div>
+					            </div>
+					            <a href="#modal2" data-target="#modal2" class="modal-button">Modal with header, but no footer</a> 
+							</div>
+							<h4 class="u-move-down-xlarge">Modal with header and footer</h4>
+							<hr>
+							<div class="flex-wrapper">
+<pre>
+<code class="line-numbers language-markup"><script type="prism-html-markup"><div id="modal3" class="ez-modal ez-modal-header" role="dialog" aria-labelledby="ez-modal">
+    <div class="modal-container">
+        <div class="modal-content">
+        	<div class="header" aria-labelledby="ez-modal_header">
+                <h2>Header here</h2>
+                <a href="#" data-dismiss="modal"><span class="ez-icon-discard"></span></a>
+            </div>
+            <div class="body" aria-labelledby="ez-modal_body">
+                Your content here
+            </div>
+            <div class="footer" aria-labelledby="ez-modal_buttons">
+                Include interaction buttons here
+            </div>
+        </div>
+    </div>
+</div></script></code>
+</pre>
+								<div id="modal3" class="ez-modal ez-modal-header" role="dialog" aria-labelledby="ez-modal">
+					                <div class="modal-container">
+					                    <div class="modal-content">
+					                        <div class="header" aria-labelledby="ez-modal_header">
+					                            <h2>Header here</h2>
+					                            <a href="#" data-dismiss="modal"><span class="ez-icon-discard"></span></a>
+					                        </div>
+					                        <div class="body" aria-labelledby="ez-modal_body">
+					                            <div class="ez-table">
+					                                <div class="table-title">
+					                                    <p>Published version</p>
+					                                </div>
+					                                <div class="table-container">
+					                                    <table>
+					                                        <tr>
+					                                            <th>Version</th>
+					                                            <th>Language</th>
+					                                            <th>Author</th>
+					                                            <th>Created</th>
+					                                            <th>Last saved</th>
+					                                        </tr>
+					                                        <tr>
+					                                            <td>2</td>
+					                                            <td>eng-GB</td>
+					                                            <td>Administrator user</td>
+					                                            <td>17 Sep 2015 12:53 PM</td>
+					                                            <td>17 Sep 2015 12:55 PM</td>
+					                                        </tr>
+					                                        <tr>
+					                                            <td>1</td>
+					                                            <td>eng-GB</td>
+					                                            <td>Administrator user</td>
+					                                            <td>15 Sep 2015 08:33 AM</td>
+					                                            <td>15 Sep 2015 11:45 AM</td>
+					                                        </tr>
+					                                    </table>
+					                                </div>
+					                            </div>
+					                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+					                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+					                        </div>
+					                        <div class="footer" aria-labelledby="ez-modal_buttons">
+					                            <a href="#" data-dismiss="modal"><button type="button" class="ez-button ez-button-neutral">Cancel</button></a>
+					                            <a href="#" data-dismiss="modal"><button type="button" class="ez-button ez-button-negative">Send to trash</button></a>
+					                        </div>
+					                    </div>
+					                </div>
+					            </div>
+					            <a href="#modal3" data-target="#modal3" class="modal-button">Modal with header and footer </a> 
 							</div>
 						</div>
 					</div>
@@ -2223,6 +2410,11 @@
 								<li>
 									<a href="#components-tables">
 										<span class="fa fa-angle-right"></span>Tables
+									</a>
+								</li>
+								<li>
+									<a href="#components-modals">
+										<span class="fa fa-angle-right"></span>Modals
 									</a>
 								</li>
 							</ul>


### PR DESCRIPTION
Most important aspects:
- Added three types of modals: [1] without header; [2] with header, but without footer; [3] with header and footer.

Improvements & issues:
- Disable scrolling background when modal is opened, by adding `overflow: hidden;`
- Width limits should be discussed and set them based on extensibility perspective. Current set `max-width: 80%;` 
- Issue: when closing the modal content automatically scrolls to the top.


<img width="1278" alt="screen shot 2017-05-11 at 6 11 05 pm" src="https://cloud.githubusercontent.com/assets/9256718/25974415/f1e29014-3676-11e7-8bb4-7beddab07180.png">